### PR TITLE
Fix color constant names

### DIFF
--- a/Arduino/grid_bot/grid_bot.ino
+++ b/Arduino/grid_bot/grid_bot.ino
@@ -555,7 +555,7 @@ void drawSettingsButton() {
   settingsButtonX = startButtonX + startButtonWidth + buttonMargin;
 
   // Draw button background
-  tft.fillRect(settingsButtonX, settingsButtonY, settingsButtonWidth, buttonHeight, ILI9341DARKGREY);
+  tft.fillRect(settingsButtonX, settingsButtonY, settingsButtonWidth, buttonHeight, ILI9341_DARKGREY);
 
   // Calculate center position for icon
   int iconX = settingsButtonX + (settingsButtonWidth - 24) / 2;  // Center 20px wide icon
@@ -574,7 +574,7 @@ void drawSettingsMenu() {
 
   // Draw menu background
   tft.fillRect(settingsMenuX, settingsMenuY, settingsMenuWidth, settingsMenuHeight, settingsMenuBackgroundColor);
-  tft.drawRect(settingsMenuX, settingsMenuY, settingsMenuWidth, settingsMenuHeight, ILI9341WHITE);
+  tft.drawRect(settingsMenuX, settingsMenuY, settingsMenuWidth, settingsMenuHeight, ILI9341_WHITE);
 
   // Set text size and color
   tft.setTextSize(2);


### PR DESCRIPTION
## Summary
- correct dark grey/white constant names in `grid_bot.ino`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68497f5cd1508326b40e8d95a5a0caf4