### PR TITLE
Fix incorrect constant name for settings icon

### DIFF
--- a/Arduino/grid_bot/grid_bot.ino
+++ b/Arduino/grid_bot/grid_bot.ino
@@ -562,7 +562,7 @@ void drawSettingsButton() {
   int iconY = settingsButtonY + (buttonHeight - 24) / 2;          // Center 20px tall icon
 
   // Draw the icon
-  tft.drawRGBBitmap(iconX, iconY, SETTINGSICONCOLOR, 24, 24);
+  tft.drawRGBBitmap(iconX, iconY, SETTINGS_ICON_COLOR, 24, 24);
 }
 
 void drawSettingsMenu() {


### PR DESCRIPTION
## Summary
- use the correct `SETTINGS_ICON_COLOR` constant when drawing the settings icon

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno Arduino/grid_bot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497f79d2248326bea0605b9ae89cbe