### PR TITLE
Fix typo variable name

### DIFF
--- a/Arduino/grid_bot/grid_bot.ino
+++ b/Arduino/grid_bot/grid_bot.ino
@@ -1154,11 +1154,11 @@ void loop() {
       //
     } else {
       // Calculate current countdown number
-      int currentNuber = (countdownDuration / 1000) - ((millis() - countdownStart) / 1000);
+      int currentNumber = (countdownDuration / 1000) - ((millis() - countdownStart) / 1000);
 
       // Only draw if number has changed
-      if (currentNuber != countdownNumber) {
-        countdownNumber = currentNuber;
+      if (currentNumber != countdownNumber) {
+        countdownNumber = currentNumber;
         drawStartButton();
       }
     }


### PR DESCRIPTION
## Summary
- rename `currentNuber` to `currentNumber` in the countdown logic

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497f8df5dc8326b08cc05ec859c2bd