### PR TITLE
Rename drawUserInterface to drawUI

### DIFF
--- a/Arduino/grid_bot/grid_bot.ino
+++ b/Arduino/grid_bot/grid_bot.ino
@@ -225,14 +225,12 @@ void setup() {
   // Initialize grid values
   initGrid();
 
-  // Calculate positions and dimensions for UI elements
-  layoutUI();
-
   // Initialize path array with default points
   initPath();
 
-  // Draw UI elements
-  drawUserInterface();
+  // Layout and draw UI
+  layoutUI();
+  drawUI();
 }
 
 void setBrightness() {
@@ -345,7 +343,7 @@ void layoutUI() {
 }
 
 
-void drawUserInterface() {
+void drawUI() {
   // Draw all UI elements
   drawGridLines();
   drawGridCells(0, numRows - 1, 0, numCols - 1);
@@ -988,7 +986,7 @@ void loop() {
 
         // Change back to idle state and redraw main interface
         uiState = IDLE;
-        drawUserInterface();
+        drawUI();
       }
 
       // Debounce delay


### PR DESCRIPTION
## Summary
- rename `drawUserInterface` to `drawUI`
- move UI layout and drawing to the end of `setup`

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e485f9fa4832698a0b4283b51d031